### PR TITLE
Revert "Update sphinx to 3.0.3" to fix a conflict

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ watchdog==0.8.3
 flake8==3.5.0
 tox==2.9.1
 coverage==4.5.1
-Sphinx==3.0.3
+Sphinx==1.7.1
 twine==1.10.0
 pyyaml>=3.1
 Click>=6.0


### PR DESCRIPTION
Reverts monash-merc/asynchy#69